### PR TITLE
Fixed incorrect variable usage

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfPTable.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfPTable.cs
@@ -1362,7 +1362,7 @@ namespace iTextSharp.text.pdf
             {
                 int col = currCol - 1;
                 aboveCell = aboveRow.GetCells()[col];
-                while ((aboveCell == null) && (row > 0))
+                while ((aboveCell == null) && (col > 0))
                     aboveCell = aboveRow.GetCells()[--col];
                 return aboveCell != null && aboveCell.Rowspan > distance;
             }


### PR DESCRIPTION
When checking if the cell is null we have a loop to get going round to find the previous cell.  If this doesn't find a cell it keeps checking for the next cell until get to 0 (the left most cell) but at the moment the check that we don't go beyond zero looks at the row count not the cell count.

One line of code change to fix this.