### PR TITLE
Fixed null reference exception while GetLayers() called

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfWriter.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfWriter.cs
@@ -3008,9 +3008,9 @@ namespace iTextSharp.text.pdf
             }
             if (grx.Size > 0)
                 d.Put(PdfName.OFF, grx);
-            if (OcgRadioGroup.Size > 0)
+            if (OcgRadioGroup != null && OcgRadioGroup.Size > 0)
                 d.Put(PdfName.Rbgroups, OcgRadioGroup);
-            if (OcgLocked.Size > 0)
+            if (OcgLocked != null && OcgLocked.Size > 0)
                 d.Put(PdfName.Locked, OcgLocked);
             addAsEvent(PdfName.View, PdfName.Zoom);
             addAsEvent(PdfName.View, PdfName.View);


### PR DESCRIPTION
Fixed null reference when called stamper.GetPdfLayers();
http://itext.2136553.n4.nabble.com/remove-watermark-layer-td2264258.html
here bug reported