### PR TITLE
Removed dispose on close method

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfSignatureAppearance.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfSignatureAppearance.cs
@@ -593,8 +593,8 @@ namespace iTextSharp.text.pdf
                     if (Originalout != null)
                         try { File.Delete(TempFile); } catch { }
                 }
-                if (Originalout != null)
-                    try { Originalout.Dispose(); } catch { }
+
+                Originalout?.Seek(0, SeekOrigin.Begin);
             }
         }
 


### PR DESCRIPTION
Removed dispose of the stream on close method, this way we can use the a MemoryStream on the creation of a PdfSignatureAppearance and retrieve the content after a PreClose() and Close() of the appearance.