### PR TITLE
netstandrad2.0 does not support AssemblyLoadContext 

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/BaseFont.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/BaseFont.cs
@@ -1146,8 +1146,10 @@ namespace iTextSharp.text.pdf
                         {
 #if NET40
                             var asm = Assembly.LoadFrom(dir);
-#else
+#elif NETSTANDARD1_3
                             var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(dir);
+#else
+                            var asm = Assembly.LoadFrom(dir);
 #endif
                             istr = asm.GetManifestResourceStream(key);
                         }


### PR DESCRIPTION
The BaseFont uses `AssemblyLoadContext ` `System.Runtime.Loader`, which is not supported in `netstandard2.0.` 

It makes a TypeLoaded Exception.

So the code changes makes a difference between versions, and when the version is `netstandard2.0` then uses `Assemlbly.LoadFrom` isntead of `AssemblyLoadContext `
