### PR TITLE
Custom XMP Data is not recognized by Acrobat

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/xml/xmp/XmpReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/xml/xmp/XmpReader.cs
@@ -94,7 +94,11 @@ namespace iTextSharp.text.xml.xmp
 
                 var xwSettings = new XmlWriterSettings
                 {
-                    Encoding = new UTF8Encoding(false)
+                    Encoding = new UTF8Encoding(false),
+                    IndentChars = "  ",
+                    Indent = true,
+                    NewLineChars = "\n",
+                    OmitXmlDeclaration = true
                 };
                 var xw = XmlWriter.Create(fout, xwSettings);
                 var xmlNode = xmpmeta[0];


### PR DESCRIPTION
iTextSharp is adding an XML declaration as if this were an XML file but it is not an XML file it's a fragment. Adobe Acrobat Pro ignores the XMP data as if it were not valid. This fixes it by adding OmitXmlDeclaration to XmlWriterSettings, and also formats the XML to more closely match a sample file I was given that was generated by the Java iText.

iTextSharp still modifies any XMP that you set on the PdfStamper class to include its name as the producer - I did not change any of that. I considered making that optional, but as long as I get a valid file those modifications don't matter to me.

I don't actually have a copy of Acrobat Pro to test this personally, but I provided files to someone who does and he sent me a screenshot before and after to show me that my XMP is showing up now.