### PR TITLE
FileStream lazy load

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
@@ -221,10 +221,11 @@ namespace iTextSharp.text.pdf
         /// </summary>
         /// <param name="isp">the  InputStream  containing the document. The stream is read to the</param>
         /// <param name="ownerPassword">the password to read the document</param>
-        public PdfReader(Stream isp, byte[] ownerPassword)
+        /// <param name="forceRead">force the read of the entire stream, even it's a FileStream</param>
+        public PdfReader(Stream isp, byte[] ownerPassword, bool forceRead = true)
         {
             Password = ownerPassword;
-            Tokens = new PrTokeniser(new RandomAccessFileOrArray(isp));
+            Tokens = new PrTokeniser(new RandomAccessFileOrArray(isp, forceRead));
             ReadPdf();
         }
 
@@ -234,7 +235,8 @@ namespace iTextSharp.text.pdf
         /// @throws IOException on error
         /// </summary>
         /// <param name="isp">the  InputStream  containing the document. The stream is read to the</param>
-        public PdfReader(Stream isp) : this(isp, null)
+        /// <param name="forceRead">force the read of the entire stream, even it's a FileStream</param>
+        public PdfReader(Stream isp, bool forceRead = true) : this(isp, null, forceRead)
         {
         }
 

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/RandomAccessFileOrArray.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/RandomAccessFileOrArray.cs
@@ -112,9 +112,17 @@ namespace iTextSharp.text.pdf
             }
         }
 
-        public RandomAccessFileOrArray(Stream isp)
+        public RandomAccessFileOrArray(Stream isp, bool forceRead = true)
         {
-            ArrayIn = InputStreamToArray(isp);
+            if (isp is FileStream fs && !forceRead)
+            {
+                Rf = fs;
+                Filename = fs.Name;
+            }
+            else
+            {
+                ArrayIn = InputStreamToArray(isp);                
+            }
         }
 
         public RandomAccessFileOrArray(byte[] arrayIn)


### PR DESCRIPTION
Changed the load of FileStream when creating a RandomAccessFileOrArray, the old version always load the entire stream even when it's a FileStream, now it can be changed using the parameter forceRead on the creation of a PdfReader.

Note: The old behavior is the default.