### PR TITLE
#95: serialize the element itself when preparing the XFA form data

### DIFF
--- a/src/iTextSharp.LGPLv2.Core.FunctionalTests/Issues/Issue95.cs
+++ b/src/iTextSharp.LGPLv2.Core.FunctionalTests/Issues/Issue95.cs
@@ -15,19 +15,24 @@ namespace iTextSharp.LGPLv2.Core.FunctionalTests.Issues
     [TestClass]
     public class Issue95
     {
+        public const string XmlRootElementName = "form1";
+        public const string XmlChildElementName = "childElement";
+
         public const string XmlDeclarationFragment = "<?xml version=";
+        public const string XmlElementRootFragment = "<form1";
 
         [TestMethod]
         public void Verify_Issue95_XfaForm_SerializeDoc_Does_Not_Add_Xml_Declaration()
         {
             var xmlDoc = new XmlDocument();
 
-            var form1 = xmlDoc.CreateElement("form1");
+            var form1 = xmlDoc.CreateElement(XmlRootElementName);
             xmlDoc.AppendChild(form1);
 
-            form1.AppendChild(xmlDoc.CreateElement("subObject"));
-            form1.AppendChild(xmlDoc.CreateElement("subObject"));
-            form1.AppendChild(xmlDoc.CreateElement("subObject"));
+            // Add some child elements
+            form1.AppendChild(xmlDoc.CreateElement(XmlChildElementName));
+            form1.AppendChild(xmlDoc.CreateElement(XmlChildElementName));
+            form1.AppendChild(xmlDoc.CreateElement(XmlChildElementName));
 
             var bytes = XfaForm.SerializeDoc(xmlDoc);
             var text = Encoding.UTF8.GetString(bytes);
@@ -38,7 +43,15 @@ namespace iTextSharp.LGPLv2.Core.FunctionalTests.Issues
                 XmlDeclarationFragment, 
                 StringComparison.InvariantCultureIgnoreCase) == 0;
 
+            // We should have the root element at the beginning of the serialized text ; this also
+            // makes sure that we're not mstakenly adding the UTF-8 identifier to the beginning of
+            // the serialized text
+            var startsWithRootelement = text.IndexOf(
+                XmlElementRootFragment,
+                StringComparison.InvariantCulture) == 0;
+
             Assert.IsFalse(containsXmlDeclaration);
+            Assert.IsTrue(startsWithRootelement);
         }
     }
 }

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/XfaForm.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/XfaForm.cs
@@ -167,7 +167,7 @@ namespace iTextSharp.text.pdf
             MemoryStream fout = new MemoryStream();
             using (XmlWriter sw = XmlWriter.Create(fout, new XmlWriterSettings
             {
-                // Specify the encoding manyally, so we can ask for the UTF
+                // Specify the encoding manually, so we can ask for the UTF
                 // identifier to not be included in the output
                 Encoding = new UTF8Encoding(false),
                 // We have to omit the XML delcaration, otherwise we'll confuse

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/XfaForm.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/XfaForm.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Text;
 using System.IO;
 using System.Xml;
+using System.Xml.Serialization;
 
 namespace iTextSharp.text.pdf
 {
@@ -164,26 +165,27 @@ namespace iTextSharp.text.pdf
         public static byte[] SerializeDoc(XmlNode n)
         {
             MemoryStream fout = new MemoryStream();
-            var xwSettings = new XmlWriterSettings
+            using (XmlWriter sw = XmlWriter.Create(fout, new XmlWriterSettings
             {
+                // Specify the encoding manyally, so we can ask for the UTF
+                // identifier to not be included in the output
                 Encoding = new UTF8Encoding(false),
-                IndentChars = "  ",
-                Indent = true,
-                NewLineChars = "\n",
                 // We have to omit the XML delcaration, otherwise we'll confuse
                 // the PDF readers when they try to process the XFA data
                 OmitXmlDeclaration = true,
-                // We don't really care if we're starting from a top-level
-                // document or an individual element
-                ConformanceLevel = ConformanceLevel.Auto
-            };
-            var xw = XmlWriter.Create(fout, xwSettings);
-            n.WriteContentTo(xw);
-#if NET40
-            xw.Close();
-#else
-            xw.Dispose();
-#endif
+            }))
+            {
+                // We use an XmlSerializer here so that we include the node itself
+                // in the output text ; if we would've used n.WriteContentTo, as
+                // the name implies, only the content of the node would have been
+                // added, instead of the full node.
+                //
+                // This does require adding the System.Xml.XmlSerializer NuGet package
+                // to the netstandard1.3 target, as it is not available out of the box
+                XmlSerializer ser = new XmlSerializer(typeof(XmlNode));
+                ser.Serialize(sw, n);
+            }
+
             return fout.ToArray();
         }
 


### PR DESCRIPTION
The previous commit did not handle the issue of the root serialized element itself missing from the output. This one fixes that, by switching to XmlSerializer.