### PR TITLE
Use BouncyCastle to do MD5 digests when running in the browser

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/MD5.cs
+++ b/src/iTextSharp.LGPLv2.Core/MD5.cs
@@ -1,0 +1,34 @@
+﻿using Org.BouncyCastle.Crypto.Digests;
+using System;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace iTextSharp
+{
+    /// <summary>
+    /// RFC1321: The MD5 Message-Digest Algorithm
+    /// https://datatracker.ietf.org/doc/html/rfc1321
+    /// </summary>
+    public sealed class MD5BouncyCastle : HashAlgorithm
+    {
+        public static new HashAlgorithm Create() =>
+            System.Runtime.InteropServices.RuntimeInformation.OSDescription == "Browser" ? new MD5BouncyCastle() : MD5.Create();
+        private MD5BouncyCastle() { }
+
+        private MD5Digest _digestInternal = new();
+
+        public override void Initialize() {}
+
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            _digestInternal.BlockUpdate(array, ibStart, cbSize);
+        }
+
+        protected override byte[] HashFinal()
+        {
+            byte[] output = new byte[_digestInternal.GetByteLength()];
+            _digestInternal.DoFinal(output, 0);
+            return output;
+        }
+    }
+}

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/ImgJBIG2.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/ImgJBIG2.cs
@@ -52,7 +52,7 @@ namespace iTextSharp.text
                 _global = globals;
                 try
                 {
-                    using (var md5 = MD5.Create())
+                    using (var md5 = MD5BouncyCastle.Create())
                     {
                         _globalHash = md5.ComputeHash(_global);
                     }

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfSmartCopy.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfSmartCopy.cs
@@ -176,7 +176,7 @@ namespace iTextSharp.text.pdf
                     serDic((PdfDictionary)obj, level - 1, bb);
                     if (level > 0)
                     {
-                        using (var md5 = MD5.Create())
+                        using (var md5 = MD5BouncyCastle.Create())
                         {
                             bb.Append(md5.ComputeHash(PdfReader.GetStreamBytesRaw((PrStream)obj)));
                         }


### PR DESCRIPTION
`System.Security.Cryptography.MD5` is unsupported by Blazor. It is useful to be able to use iTextSharp from the browser platform.

This pull requests makes it check if it is running in the browser and if so use BouncyCastle instead of System.Security.Cryptography for MD5.