### PR TITLE
Fix recusion check for large stacktraces

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
@@ -12,6 +12,7 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Cms;
 using Org.BouncyCastle.X509;
 using System.Diagnostics;
+using System.Linq;
 
 namespace iTextSharp.text.pdf
 {
@@ -3076,7 +3077,7 @@ namespace iTextSharp.text.pdf
                 return true;
             
             //before we go on, let's make sure we haven't done this a number of times that indicates a problematic recursion loop
-            if (new StackTrace().FrameCount > 200)
+            if ((new StackTrace().GetFrames() ?? Array.Empty<StackFrame>()).Count(frame => frame.GetMethod().Name == nameof(ReadXRefStream)) > 200)
             {
                 _bBailout = true;
                 throw new StackOverflowException("Likely recursion loop issue.");


### PR DESCRIPTION
ASP.NET Core applications have pretty large stacktraces (if using many async methods). iTextSharp silently failed is such cases (because it checked the whole stacktrace but should check only the possible recursion loop)