### PR TITLE
Migrate to new `BouncyCastle.Cryptography` NuGet package.

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
@@ -48,7 +48,7 @@
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>NET40</DefineConstants>

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/OcspClientBouncyCastle.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/OcspClientBouncyCastle.cs
@@ -129,8 +129,8 @@ namespace iTextSharp.text.pdf
             gen.AddRequest(id);
 
             // create details for nonce extension
-            var oids = new List<object>();
-            var values = new List<object>();
+            var oids = new List<DerObjectIdentifier>();
+            var values = new List<X509Extension>();
 
             oids.Add(OcspObjectIdentifiers.PkixOcspNonce);
             values.Add(new X509Extension(false, new DerOctetString(new DerOctetString(PdfEncryption.CreateDocumentId()).GetEncoded())));

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/crypto/AESCipher.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/crypto/AESCipher.cs
@@ -21,7 +21,7 @@ namespace iTextSharp.text.pdf.crypto
         {
             IBlockCipher aes = new AesEngine();
             IBlockCipher cbc = new CbcBlockCipher(aes);
-            _bp = new PaddedBufferedBlockCipher(cbc);
+            _bp = new PaddedBufferedBlockCipher(cbc, new Pkcs7Padding());
             KeyParameter kp = new KeyParameter(key);
             ParametersWithIV piv = new ParametersWithIV(kp, iv);
             _bp.Init(forEncryption, piv);


### PR DESCRIPTION
This PR migrates project from old `Portable.BouncyCastle` package to the new `BouncyCastle.Cryptography` package.