### PR TITLE
.NET Framework bug fix for UTC dates

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfDate.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfDate.cs
@@ -27,7 +27,8 @@ public class PdfDate : PdfString
         //d = d.ToUniversalTime();
 
         Value = d.ToString("\\D\\:yyyyMMddHHmmss", DateTimeFormatInfo.InvariantInfo);
-        var timezone = d.ToString("zzz", DateTimeFormatInfo.InvariantInfo);
+        // bug fix for .NET Framework - see https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#zzzSpecifier
+        var timezone = d.Kind == DateTimeKind.Utc ? "+00:00" : d.ToString("zzz", DateTimeFormatInfo.InvariantInfo);
         timezone = timezone.Replace(":", "'");
         Value += timezone + "'";
     }


### PR DESCRIPTION
On the .NET Framework, the `zzz` format specifier returns the local time offset even if the `Kind` property is `Utc`.  This has been changed in .NET Core.  This fix aligns behavior so that dates with `DateTime.UtcNow` can be used properly on .NET Framework.