### PR TITLE
Cleanup dependencies

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
@@ -52,13 +52,6 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0"/>
-        <PackageReference Include="System.Net.Requests" Version="4.3.0"/>
-        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0"/>
-        <PackageReference Include="System.Runtime.Loader" Version="4.3.0"/>
-        <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1"/>
-        <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1"/>
-        <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0"/>
         <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0"/>
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
All of the `System.*` dependencies with version `4` are unnecessary in `netstandard2.0` and can be removed. They are left over from `netstandard1.x`.

Removing these dependencies can also solve issues with certain build systems due to the invalid `netcore5.0` target in some of these packages.

In Visual Studio, these old dependencies would cause it to falsely state that it is installing a very large number of old packages (even though it actually ignores them, thankfully, but this may not be the case for legacy projects):
![image](https://github.com/VahidN/iTextSharp.LGPLv2.Core/assets/5132940/c87e49ae-72a7-4d11-951b-1bce7f0823a9)
