### PR TITLE
Verify if the image is encoded in base64 before treating it as a URL.

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/Image.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/Image.cs
@@ -1,4 +1,4 @@
-using iTextSharp.LGPLv2.Core.System.Drawing;
+﻿using iTextSharp.LGPLv2.Core.System.Drawing;
 using iTextSharp.LGPLv2.Core.System.NetUtils;
 using iTextSharp.text.pdf;
 using iTextSharp.text.pdf.codec;
@@ -1203,7 +1203,22 @@ public abstract class Image : Rectangle
     /// </summary>
     /// <param name="filename">a filename</param>
     /// <returns>an object of type Gif, Jpeg or Png</returns>
-    public static Image GetInstance(string filename) => GetInstance(Utilities.ToUrl(filename));
+    public static Image GetInstance(string filename)
+    {
+        if (string.IsNullOrEmpty(filename)) throw new ArgumentNullException(nameof(filename));
+
+        if (filename.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+        {
+            // data:[<MIME-type>][;charset=<encoding>][;base64],<data>
+            var base64Data = filename.Substring(filename.IndexOf(",", StringComparison.OrdinalIgnoreCase) + 1);
+            var imagedata = Convert.FromBase64String(base64Data);
+            return GetInstance(imagedata);
+        }
+        else
+        {
+            return GetInstance(Utilities.ToUrl(filename));
+        }
+    }
 
     /// <summary>
     ///     Gets an instance of an Image in raw mode.


### PR DESCRIPTION
When creating a PDF from HTML, if the 'img' tag contains a base64-encoded image, it attempts to convert it into a URL. In the case of small images, it works well, but for larger images, it generates an exception. By verifying in advance if the 'img' tag contains a base64 image and handling it specifically, the issue is resolved.