### PR TITLE
Improve SmartPdfCopy compression and performance

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfCopy.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfCopy.cs
@@ -937,7 +937,7 @@ public class PdfCopy : PdfWriter
                 return false;
             }
 
-            return Gen == other.Gen && Num == other.Num;
+            return Num == other.Num && Gen == other.Gen;
         }
 
         public override int GetHashCode() => (Gen << 16) + Num;


### PR DESCRIPTION
- Re-introduced detection of duplicate dictionaries
- Don't visit previously processed references while attempting to detect duplicate streams/dictionaries