### PR TITLE
Improve SmartPdfCopy compression and performance

### DIFF
--- a/src/iTextSharp.LGPLv2.Core.FunctionalTests/PdfSmartCopyTests.cs
+++ b/src/iTextSharp.LGPLv2.Core.FunctionalTests/PdfSmartCopyTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using iTextSharp.text;
 using iTextSharp.text.pdf;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,7 +11,7 @@ namespace iTextSharp.LGPLv2.Core.FunctionalTests;
 public class PdfSmartCopyTests
 {
     [TestMethod]
-    public void Verify_Remove_Duplicate_Objects_Works()
+    public void Verify_Remove_Duplicate_Streams_Works()
     {
         var inputFile = CreateALargePdfFile();
         var outFile = TestUtils.GetOutputFileName();
@@ -20,25 +22,29 @@ public class PdfSmartCopyTests
         Assert.IsTrue(new FileInfo(inputFile).Length > new FileInfo(outFile).Length);
     }
 
+    [TestMethod]
+    public void Verify_Remove_Duplicate_Dictionaries_Works()
+    {
+        var inputFile = CreatePdfFileWithEmbeddedFont();
+        var outFile = TestUtils.GetOutputFileName();
+
+        CompressMultiplePdfFilesRemoveDuplicateObjects(inputFile, outFile);
+
+        TestUtils.VerifyPdfFileIsReadable(outFile);
+
+        using var reader = new PdfReader(outFile);
+        var fontCount = GetPdfObjects(reader)
+            .OfType<PdfDictionary>()
+            .Select(d => d.GetDirectObject(PdfName.TYPE))
+            .Where(PdfName.Fontdescriptor.Equals)
+            .Count();
+
+        Assert.AreEqual(1, fontCount);
+    }
+
     private static void CompressPdfFileRemoveDuplicateObjects(string inputFile, string outFile)
     {
-        using var fileStream = new FileStream(outFile, FileMode.Create);
-        using var pdfDoc = new Document();
-        var pdfSmartCopy = new PdfSmartCopy(pdfDoc, fileStream);
-        pdfSmartCopy.SetFullCompression();
-
-        pdfDoc.AddAuthor(TestUtils.Author);
-        pdfDoc.Open();
-
-        using var reader = new PdfReader(inputFile);
-
-        var n = reader.NumberOfPages;
-        for (var page = 0; page < n;)
-        {
-            pdfSmartCopy.AddPage(pdfSmartCopy.GetImportedPage(reader, ++page));
-        }
-
-        pdfSmartCopy.FreeReader(reader);
+        CompressMultiplePdfFilesRemoveDuplicateObjects(inputFile, outFile, 1);
     }
 
     private string CreateALargePdfFile()
@@ -48,7 +54,7 @@ public class PdfSmartCopyTests
         {
             using (var pdfDoc = new Document(PageSize.A4))
             {
-                var pdfWriter = PdfWriter.GetInstance(pdfDoc, fileStream);
+                PdfWriter.GetInstance(pdfDoc, fileStream);
 
                 pdfDoc.AddAuthor(TestUtils.Author);
                 pdfDoc.Open();
@@ -65,5 +71,58 @@ public class PdfSmartCopyTests
 
         TestUtils.VerifyPdfFileIsReadable(pdfFilePath);
         return pdfFilePath;
+    }
+
+    private string CreatePdfFileWithEmbeddedFont()
+    {
+        var pdfFilePath = TestUtils.GetOutputFileName();
+        using (var fileStream = new FileStream(pdfFilePath, FileMode.Create))
+        {
+            using (var pdfDoc = new Document(PageSize.A4))
+            {
+                PdfWriter.GetInstance(pdfDoc, fileStream);
+                pdfDoc.AddAuthor(TestUtils.Author);
+                pdfDoc.Open();
+                
+                var font =  TestUtils.GetUnicodeFont("Tahoma", TestUtils.GetTahomaFontPath(), 10, Font.NORMAL, BaseColor.Black);
+                pdfDoc.Add(new Paragraph("Document with embedded font", font));
+            }
+        }
+        
+        TestUtils.VerifyPdfFileIsReadable(pdfFilePath);
+        return pdfFilePath;
+    }
+    
+        
+    private static void CompressMultiplePdfFilesRemoveDuplicateObjects(string inputFile, string outFile, int times = 10)
+    {
+        using var fileStream = new FileStream(outFile, FileMode.Create);
+        using var pdfDoc = new Document();
+        var pdfSmartCopy = new PdfSmartCopy(pdfDoc, fileStream);
+        pdfSmartCopy.SetFullCompression();
+
+        pdfDoc.AddAuthor(TestUtils.Author);
+        pdfDoc.Open();
+
+        // The same document has been added multiple times
+        // This will cause duplicate dictionaries (ex: FontDescriptors)
+        for (var i = 0; i < times; ++i)
+        {
+            using var reader = new PdfReader(inputFile);
+
+            var n = reader.NumberOfPages;
+            for (var page = 0; page < n;)
+            {
+                pdfSmartCopy.AddPage(pdfSmartCopy.GetImportedPage(reader, ++page));
+            }
+
+            pdfSmartCopy.FreeReader(reader);
+        }
+    }
+    
+    private IEnumerable<object> GetPdfObjects(PdfReader reader)
+    {
+        for (var idx = 0; idx < reader.XrefSize; ++idx)
+            yield return reader.GetPdfObjectRelease(idx);
     }
 }

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfCopy.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfCopy.cs
@@ -937,7 +937,7 @@ public class PdfCopy : PdfWriter
                 return false;
             }
 
-            return Gen == other.Gen && Num == other.Num;
+            return Num == other.Num && Gen == other.Gen;
         }
 
         public override int GetHashCode() => (Gen << 16) + Num;


### PR DESCRIPTION
- Re-introduced detection of duplicate dictionaries
- Don't visit previously processed references while attempting to detect duplicate streams/dictionaries

While correcting a bug that caused an infinite loop in SmartPdfCopy when handling certain documents (https://github.com/VahidN/iTextSharp.LGPLv2.Core/issues/124), we have lost the ability to remove duplicate dictionaries.

This causes the document to become unnecessarily large when appending multiple documents that are based on the same template (eg: thousands of documents prepared for a print job)

These changes restore that capability, and prevent re-visiting the same nodes when detecting identical content, or already processed nodes, improving performance handling many streams/dictionaries (especially recursive)