### PR TITLE
Fix TrueTypeFontUnicode when metrics contains null

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/TrueTypeFontUnicode.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/TrueTypeFontUnicode.cs
@@ -324,7 +324,7 @@ internal class TrueTypeFontUnicode : TrueTypeFont, IComparer<int[]>
             tmp.Add(o);
         }
 
-        var metrics = tmp.ToArray();
+        var metrics = tmp.Where(m => m != null).ToArray();
         Array.Sort(metrics, this);
         PdfIndirectReference indFont = null;
         PdfObject pobj = null;


### PR DESCRIPTION
TrueTypeFontUnicode WriteFont() method throws when metrics contains null values. This commit fixes the issue by filtering out null values