### PR TITLE
Cleanup xrefObj on Dispose

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
@@ -594,6 +594,9 @@ public class PdfReader : IPdfViewerPreferences, IDisposable
     public void Dispose()
     {
         Close();
+
+        // Ensure large pdf cleaned up before continuing
+        _xrefObj.Clear();
     }
 
     /// <summary>


### PR DESCRIPTION
Hello, here is a pull request to reduce memory usage after cleanup. In my tests with large files, memory usage at the end is 377 MB instead of 703 MB.

Fixes #143 