### PR TITLE
fix: fix negative index error on RemoveUnusedNode when open pdf with …

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
@@ -4142,7 +4142,7 @@ public class PdfReader : IPdfViewerPreferences, IDisposable
                         var refi = (PrIndirectReference)obj;
                         var num = refi.Number;
 
-                        if (!hits[num])
+                        if (num > 0 && !hits[num])
                         {
                             hits[num] = true;
                             state.Push(GetPdfObjectRelease(refi));
@@ -4180,7 +4180,7 @@ public class PdfReader : IPdfViewerPreferences, IDisposable
                     {
                         var num = ((PrIndirectReference)v).Number;
 
-                        if (num >= _xrefObj.Count || (!_partial && _xrefObj[num] == null))
+                        if (num > 0 && (num >= _xrefObj.Count || (!_partial && _xrefObj[num] == null)))
                         {
                             ar[k] = PdfNull.Pdfnull;
 
@@ -4217,7 +4217,7 @@ public class PdfReader : IPdfViewerPreferences, IDisposable
                     {
                         var num = ((PrIndirectReference)v).Number;
 
-                        if (num >= _xrefObj.Count || (!_partial && _xrefObj[num] == null))
+                        if (num > 0 && (num >= _xrefObj.Count || (!_partial && _xrefObj[num] == null)))
                         {
                             dic.Put(key, PdfNull.Pdfnull);
 


### PR DESCRIPTION
Hello @VahidN, how are you?
We are using your fork of iTextSharp in our software and have encountered a very specific issue. We have a PDF document that contains a link element with a reference that appears to be invalid: 
<img width="499" alt="pdf_file_content" src="https://github.com/user-attachments/assets/185b36aa-4b8b-4b7a-b1f3-c6b0d0d24c70">

This does not compromise the PDF itself, but it generates an error when opening the PDF with the PdfReader class:
<img width="649" alt="error_at_open" src="https://github.com/user-attachments/assets/cec4a54c-4110-4c15-b5b6-9867e095f264">

I am opening this pull request with the correction made. Unfortunately, I couldn't find another PDF with the same problem, and the PDF I have is owned by a client, so I don't have permission to share it. For this reason, I am not including a test along with the code.