### PR TITLE
fix: Fix opening a pdf file when the root node of the page tree is a simplified page dictionary

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfReader.cs
@@ -3279,9 +3279,12 @@ public class PdfReader : IPdfViewerPreferences, IDisposable
     {
         var type = _rootPages.Get(PdfName.TYPE);
         var types = _rootPages.Get(PdfName.TYPES);
-
-        return PdfName.Pages.Equals(type) || PdfName.Pages.Equals(types);
+        
+        return PdfName.Pages.Equals(type) || PdfName.Pages.Equals(types) || IsSimplifiedPageDictionaryRootPage();
     }
+
+    private bool IsSimplifiedPageDictionaryRootPage() =>
+        _rootPages.Get(PdfName.Kids) != null;
 
     protected internal virtual void ReadPdf()
     {


### PR DESCRIPTION
There are PDF files whose page root structure contains only the /Kids and /Count entries, this means that the root node of the page tree is a simplified page dictionary. In this context, the /Kids entry contains a list of references to other nodes or pages and the /Count entry indicates the total number of pages in the document.