### PR TITLE
fix: Ensure array accessor for width array is in bounds

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfPTable.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/PdfPTable.cs
@@ -1363,7 +1363,8 @@ public class PdfPTable : ILargeElement
             lastRow = Math.Max(lastRow, headerRows);
         }
 
-        var widths = new float[(includeHeaders ? headerRows : 0) + lastRow - firstRow][];
+        var numWidths = (includeHeaders ? headerRows : 0) + lastRow - firstRow;
+        var widths = new float[numWidths][];
 
         if (IsColspan)
         {
@@ -1371,7 +1372,7 @@ public class PdfPTable : ILargeElement
 
             if (includeHeaders)
             {
-                for (var k = 0; k < headerRows; ++k)
+                for (var k = 0; k < headerRows && n < numWidths; ++k)
                 {
                     var row = rows[k];
 
@@ -1386,7 +1387,7 @@ public class PdfPTable : ILargeElement
                 }
             }
 
-            for (; firstRow < lastRow; ++firstRow)
+            for (; firstRow < lastRow && n < numWidths; ++firstRow)
             {
                 var row = rows[firstRow];
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

This only happens for us under dotnet9 (or newer) in docker-hosted environments.
Under these circumstances we get an IndexOutOfBounds error for complex Documents with nested tables. This error only appears after a number of tries, the first documents where always successfull. For our more cpmolex  Documents the fourth one would create the error and everyone after that aswell. I tracked the source down to the for-loop for calculating the eventwidths. Somehow the value for `firstRow` gets set to `0` even when there are headerRows. This results in the second loop to have one iteration too many and trying to access an index of `widths` that is out of bounds.  
I could not determine how the `firstRow` value get's reset. I only found this by adding Debug lines before line 1390 and then in the loop. Before the loop the value is as expected `1` but then in the loop the value is `0`.  
As i was unable to reproduce this behaviour when running locally I did not succeed in writing tests for it.

## What is the new behavior?
This PRs makes sure that the index used for accessing the width array is not out of bounds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
I also noticed that adding an excessive amount of console output lines or buliding as debug will also not trigger the error to appear which leads me to think that the reason for the value reset is some threading issues. However I could not find out where those would come from so I did not engage any further.

These screenshots show the Console output and the added lines for debugging. Please excuse the german - I Hope it still get's the point across.

<img width="501" height="111" alt="image" src="https://github.com/user-attachments/assets/b7664150-42fe-4015-88c1-aca434613c96" />
<img width="1199" height="525" alt="image" src="https://github.com/user-attachments/assets/b51acc67-9367-49d5-9ceb-dfd8be2cd059" />

