### PR TITLE
fix: prevent removal of whitespaces after escaped html entities

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp.LGPLv2.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>iTextSharp.LGPLv2.Core is an unofficial port of the last LGPL version of the iTextSharp (V4.1.6) to .NET Core.</Description>
-        <VersionPrefix>3.7.7</VersionPrefix>
+        <VersionPrefix>3.7.8</VersionPrefix>
         <Authors>Vahid Nasiri</Authors>
         <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.0;net462;</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/xml/simpleparser/SimpleXMLParser.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/xml/simpleparser/SimpleXMLParser.cs
@@ -616,6 +616,7 @@ public sealed class SimpleXmlParser
                         saveState(State);
                         entity.Length = 0;
                         State = Entity;
+                        Nowhite = true;
                     }
                     else if (char.IsWhiteSpace((char)Character))
                     {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Currently SimpleXMLParser class removes whitespace following immediately after HTML encoded entities. That means that ex. French accent letters like à or a character & have the space immediately after them removed.

Closes #

## What is the new behavior?

SimpleXMLParser now treats HTML escaped entities like not whitespace characters

<img width="1812" height="501" alt="image" src="https://github.com/user-attachments/assets/bcd668fc-b00c-40c1-af41-7d2b716333cc" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Any suggestions how to make a test for this change? I couldn't find any tests that would compare PDFs on such level.