### PR TITLE
fix: use cryptographically secure RNG for IV generation

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/crypto/IVGenerator.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/crypto/IVGenerator.cs
@@ -1,27 +1,14 @@
+using System.Security.Cryptography;
+
 namespace iTextSharp.text.pdf.crypto;
 
 /// <summary>
-///     An initialization vector generator for a CBC block encryption. It's a random generator based on RC4.
+///     An initialization vector generator for a CBC block encryption.
+///     Uses cryptographically secure random number generation.
 ///     @author Paulo Soares (psoares@consiste.pt)
 /// </summary>
 public static class IvGenerator
 {
-    private static readonly ArcfourEncryption _rc4;
-
-    static IvGenerator()
-    {
-        _rc4 = new ArcfourEncryption();
-        var longBytes = new byte[8];
-        var val = DateTime.Now.Ticks;
-        for (var i = 0; i != 8; i++)
-        {
-            longBytes[i] = (byte)val;
-            val = (long)((ulong)val >> 8);
-        }
-
-        _rc4.PrepareArcfourKey(longBytes);
-    }
-
     /// <summary>
     ///     Gets a 16 byte random initialization vector.
     /// </summary>
@@ -36,11 +23,10 @@ public static class IvGenerator
     public static byte[] GetIv(int len)
     {
         var b = new byte[len];
-        lock (_rc4)
+        using (var rng = RandomNumberGenerator.Create())
         {
-            _rc4.EncryptArcfour(b);
+            rng.GetBytes(b);
         }
-
         return b;
     }
 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The `IvGenerator` class uses a predictable pseudo-random number generator seeded with `DateTime.Now.Ticks` for generating initialization vectors (IVs) used in PDF encryption. This is a **critical security vulnerability**.

**Security Impact:**
- An attacker who knows the approximate PDF creation time (within hours/days) can predict the IV
- Predictable IVs allow decryption of encrypted PDF content
- Affects anyone using the library to create encrypted PDFs

The vulnerable code:
```csharp
static IvGenerator()
{
    _rc4 = new ArcfourEncryption();
    var val = DateTime.Now.Ticks;  // Predictable seed!
    // Seeds RC4 with timestamp...
}
```

What is the new behavior?

Replaced the predictable RC4-based PRNG with .NET's cryptographically secure RandomNumberGenerator:

```csharp
public static byte[] GetIv(int len)
{
    var b = new byte[len];
    using (var rng = RandomNumberGenerator.Create())
    {
        rng.GetBytes(b);
    }
    return b;
}
```

This ensures:
- ✅ Cryptographically secure random IVs
- ✅ No predictability based on creation time
- ✅ Proper entropy for encryption security (prevents chosen plaintext attacks)
- ✅ Simpler, more maintainable code (removed RC4 complexity)

Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

The change is a drop-in replacement with the same API. All existing code continues to work unchanged, with improved security.